### PR TITLE
Small typo in end-to-end test.

### DIFF
--- a/integration_test/end_to_end_test.go
+++ b/integration_test/end_to_end_test.go
@@ -197,17 +197,17 @@ func GetChains(t *testing.T) (*fabric_sdk.Chain, *fabric_sdk.Chain) {
 	if user == nil {
 		msps, err1 := msp.NewMSPServices(config.GetMspClientPath())
 		if err1 != nil {
-			t.Fatalf("NewFabricCOPServices return error: %v", err)
+			t.Fatalf("NewFabricCOPServices return error: %v", err1)
 		}
 		key, cert, err1 := msps.Enroll("testUser", "user1")
 		keyPem, _ := pem.Decode(key)
 		if err1 != nil {
-			t.Fatalf("Enroll return error: %v", err)
+			t.Fatalf("Enroll return error: %v", err1)
 		}
 		user := fabric_sdk.NewUser("testUser")
 		k, err1 := client.GetCryptoSuite().KeyImport(keyPem.Bytes, &bccsp.ECDSAPrivateKeyImportOpts{Temporary: false})
 		if err1 != nil {
-			t.Fatalf("KeyImport return error: %v", err)
+			t.Fatalf("KeyImport return error: %v", err1)
 		}
 		user.SetPrivateKey(k)
 		user.SetEnrollmentCertificate(cert)


### PR DESCRIPTION
On `err1 != nil`, we'd like to see what its value is.